### PR TITLE
Fix documentation issues

### DIFF
--- a/docs/src/gallery.md
+++ b/docs/src/gallery.md
@@ -1,5 +1,5 @@
-## User Creations
+## [User Creations](@id user_creations)
 
 Nothing here yet. Please feel free to submit a pull request or issue with your creations to be added
-to this section. You can use the example markup in the [Tutorial](tutorial.html) file to dynamically
+to this section. You can use the example markup in the [Tutorial](@ref first_steps) file to dynamically
 generate your images.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -13,7 +13,7 @@ pkg> add CoherentNoise
 ## Basic Usage
 
 The following is only a brief explanation of basic usage. For more advanced usage examples, please
-see the [Tutorial](tutorial.html) section.
+see the [Tutorial](@ref first_steps) section.
 
 To get started, let's get a feel for how to create a sampler and sample from it for one of the
 supported noise algorithms. Perlin noise is a well-known algorithm so let's create a 2-dimensional
@@ -78,4 +78,4 @@ per-sampler basis.
 
 Of particular note is that all samplers accept a `seed` keyword argument; even those that don't make
 use of any random numbers in their implementation. This is required for the composition pipeline
-feature described in the [Tutorial](tutorial.html).
+feature described in the [Tutorial](@ref first_steps).

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,3 +1,4 @@
+# API Reference
 ```@autodocs
 Modules = [
   CoherentNoise.Common,

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -7,10 +7,10 @@ function generate(file, sampler; xbounds=(-1.0, 1.0), ybounds=(-1.0, 1.0), color
 end
 ```
 
-# First steps
+# [First steps](@id first_steps)
 
 Before following along with this tutorial, it is a good idea to get familiar with how to work with
-samplers. See [Getting Started](getting_started.html).
+samplers. See [Getting Started](@ref installation).
 
 ## Visualizing results
 
@@ -124,9 +124,9 @@ generate("tutorial07", scaled) # hide
 
 We decreased the scale by 4, making the result look much more interesting.
 
-There are many more modifiers. It is recommended to check out the [API Reference](reference.html)
+There are many more modifiers. It is recommended to check out the [API Reference](@ref)
 for a full list of modifiers (and other samplers). Also, be sure to check out the
-[Gallery](gallery.html) for more examples.
+[Gallery](@ref user_creations) for more examples.
 
 ## Pipelines
 

--- a/src/noise_opensimplex2.jl
+++ b/src/noise_opensimplex2.jl
@@ -8,12 +8,12 @@ using ..Noise: NoiseSampler
 
 """
 Supertype of all orientations that can be applied to the [`OpenSimplex2`](@ref) or
-[`OpenSimplex2S`](@ref) sampler types to re-orient the noise space.
+[`OpenSimplex2S`](@ref Main.CoherentNoise.Noise.OpenSimplex2SNoise.OpenSimplex2S) sampler types to re-orient the noise space.
 """
 abstract type Orientation end
 
 """
-The standard orientation for [`OpenSimple2`](@ref) and [`OpenSimplex2S`](@ref).
+The standard orientation for [`OpenSimplex2`](@ref) and [`OpenSimplex2S`](@ref Main.CoherentNoise.Noise.OpenSimplex2SNoise.OpenSimplex2S).
 """
 struct Standard <: Orientation end
 """
@@ -37,7 +37,7 @@ struct ImproveXYZ <: Orientation end
 """
 An `N`-dimensional sampler that generates OpenSimplex2 noise, with an orientation of `O`.
 
-OpenSimplex2 is not as smooth as [`OpenSimplex2S`](@ref), although more performant.
+OpenSimplex2 is not as smooth as [`OpenSimplex2S`](@ref Main.CoherentNoise.Noise.OpenSimplex2SNoise.OpenSimplex2S), although more performant.
 
 `N` must be an integer in the range [2, 4].
 

--- a/src/noise_opensimplex2s.jl
+++ b/src/noise_opensimplex2s.jl
@@ -11,7 +11,7 @@ using ..OpenSimplex2Noise: Orientation, Standard, ImproveX, ImproveXY, ImproveXZ
 """
 An `N`-dimensional sampler that generates OpenSimplex2S noise, with an orientation of `O`.
 
-OpenSimplex2S is smoother than [`OpenSimplex2`](@ref), at the expense of being less performant.
+OpenSimplex2S is smoother than [`OpenSimplex2`](@ref Main.CoherentNoise.Noise.OpenSimplex2Noise.OpenSimplex2), at the expense of being less performant.
 
 `N` must be an integer in the range [2, 4].
 


### PR DESCRIPTION
**OpenSimplex2 and OpenSimplex2S references in docstring**

`OpenSimplex2S` isn't in scope in noise_opensimplex2.jl and vice versa, so use fully qualified names to fix reference issues. 

**"invalid local link: unresolved path" warnings** 

I'll add the fix for this after further discussion, in a second commit. (Edit: Done.)