### PR TITLE
fix: more documentation issues

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,7 +1,7 @@
 ```@setup getting-started
 using CoherentNoise
 ```
-## Installation
+## [Installation](@id installation)
 
 CoherentNoise.jl exists in the Julia's General registry. In Julia ≥ 1.0, you can add it using the
 package manager with:

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -27,7 +27,7 @@ gen_image(sampler)
 generate("tutorial01", sampler) # hide
 ```
 
-This produces an array of RGB values using [Images.jl](https://github.com/JuliaImages/Images.jl).
+This produces an array of RGB values using [ColorTypes.jl](https://github.com/JuliaGraphics/ColorTypes.jl).
 You can then, write it out as an image file with something like:
 
 ```@julia

--- a/src/fractal_billow.jl
+++ b/src/fractal_billow.jl
@@ -13,7 +13,7 @@ struct Billow{N,S,O} <: FractalSampler{N}
 end
 
 """
-    Billow{N}(; <kwargs>)
+    Billow{N}(; kwargs...)
 
 Construct a sampler that outputs an `N`-dimensional billowy fractal noise when it is sampler from.
 

--- a/src/fractal_fbm.jl
+++ b/src/fractal_fbm.jl
@@ -13,7 +13,7 @@ struct FBM{N,S,O} <: FractalSampler{N}
 end
 
 """
-    FBM{N}(; <kwargs>)
+    FBM{N}(; kwargs...)
 
 Construct a sampler that outputs an `N`-dimensional fractional Brownian motion fractal noise when it
 is sampler from.

--- a/src/fractal_hybrid.jl
+++ b/src/fractal_hybrid.jl
@@ -13,7 +13,7 @@ struct Hybrid{N,S,O} <: FractalSampler{N}
 end
 
 """
-    Hybrid{N}(; <kwargs>)
+    Hybrid{N}(; kwargs...)
 
 Construct a sampler that outputs an `N`-dimensional hybrid multifractal noise when it is sampler
 from.

--- a/src/fractal_multifractal.jl
+++ b/src/fractal_multifractal.jl
@@ -13,7 +13,7 @@ struct Multifractal{N,S,O} <: FractalSampler{N}
 end
 
 """
-    Multifractal{N}(; <kwargs>)
+    Multifractal{N}(; kwargs...)
 
 Construct a sampler that outputs an `N`-dimensional multifractal noise when it is sampler from.
 

--- a/src/fractal_ridged.jl
+++ b/src/fractal_ridged.jl
@@ -13,7 +13,7 @@ struct Ridged{N,S,O} <: FractalSampler{N}
 end
 
 """
-    Ridged{N}(; <kwargs>)
+    Ridged{N}(; kwargs...)
 
 Construct a sampler that outputs an `N`-dimensional ridged multifractal noise when it is sampler
 from.

--- a/src/image.jl
+++ b/src/image.jl
@@ -1,7 +1,7 @@
 """
-    gen_image(sampler::AbstractSampler; <kwargs>)
+    gen_image(sampler::AbstractSampler; kwargs...)
 
-Construct a 2-dimensional array of `Images.RGB` values, suitable for writing to disk as an image
+Construct a 2-dimensional array of `ColorTypes.RGB` values, suitable for writing to disk as an image
 file.
 
 # Arguments

--- a/src/mod_select.jl
+++ b/src/mod_select.jl
@@ -9,7 +9,7 @@ struct Select{N,S1,S2,C} <: ModifierSampler{N}
 end
 
 """
-    select(x::AbstractSampler, y::AbstractSampler; <kwargs>)
+    select(x::AbstractSampler, y::AbstractSampler; kwargs...)
 
 Construct a modifier sampler that outputs either the out of sampler `x` or `y`, depending on the
 output of sampler `z`.

--- a/src/mod_turbulence.jl
+++ b/src/mod_turbulence.jl
@@ -10,7 +10,7 @@ struct Turbulence{N,N1,N2,S1,S2} <: ModifierSampler{N}
 end
 
 """
-    turbulence(s1::AbstractSampler; s2::AbstractSampler; <kwargs>)
+    turbulence(s1::AbstractSampler; s2::AbstractSampler; kwargs...)
 
 Construct a modifier sampler that displaces the input coordinates of sampler `s1` by the output of
 sampler `s2` with a fractional Brownian motion fractal applied to it.

--- a/src/mod_warp.jl
+++ b/src/mod_warp.jl
@@ -5,7 +5,7 @@ struct Warp{N,N1,N2,N3,N4,S,SX,SY,SZ,SW} <: ModifierSampler{N}
 end
 
 """
-    warp(source::AbstractSampler; <kwargs>)
+    warp(source::AbstractSampler; kwargs...)
 
 Construct a modifier sampler that performs domain warping of the sampler `source` before sampling
 from it.

--- a/src/noise_opensimplex.jl
+++ b/src/noise_opensimplex.jl
@@ -12,7 +12,8 @@ An `N`-dimensional sampler that generates OpenSimplex (legacy) noise.
 `N` must be an integer in the range [2, 4].
 
 Note: This version of OpenSimplex is considered "legacy" by its original author. Consider using one
-of the newer algorithms, `OpenSimplex2` or `OpenSimplex2S`.
+of the newer algorithms, [`OpenSimplex2`](@ref Main.CoherentNoise.Noise.OpenSimplex2Noise.OpenSimplex2) 
+or [`OpenSimplex2S`](@ref Main.CoherentNoise.Noise.OpenSimplex2SNoise.OpenSimplex2S).
 """
 struct OpenSimplex{N} <: NoiseSampler{N}
     random_state::RandomState


### PR DESCRIPTION
Fix `Installation` in `getting_started.md` not having an `@id`

Change references to `Images.RGB` to `ColorTypes.RGB`

Change `<kwargs>` in signatures to `kwargs...` as per convention

Turn into links the references to `OpenSimplex2` and `OpenSimplex2S` in the
docstring for `OpenSimplex`